### PR TITLE
[⚛️ React Docs] Breadcrumbs UI 기능 구현 및 라우터 연동

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+## ⚛️ React Docs 기반 학습 PR
+
+- Branch: 브랜치명을 작성해 주세요.
+- Subject: 어떤 내용을 학습하고 구현했는지 간단히 설명해주세요.
+
+<br>
+
+## 🧾 Commit Messages
+
+- 커밋 메세지를 작성해주세요.
+
+<br>
+
+## 🧩 Implementation
+
+- 어떤 기능을 구현했는지 구체적으로 작성해 주세요.
+- `useLocation()`을 사용하여 현재 URL을 추적
+- 경로 조각을 `LABELS`로 매핑해 텍스트 표시
+
+<br>
+
+## 📌 What I Learned
+
+- 학습하면서 새롭게 알게 된 내용을 정리해 주세요.
+- React Router의 `pathname`을 통해 UI를 동적으로 제어하는 방법
+- 가상 breadcrumb 처리 로직 (`virtual`) 개념
+
+<br>
+
+## 📚 Reference
+
+- [링크/문서/블로그]
+
+<br>
+
+---
+
+💡 이 브랜치는 React 공식 문서 기반 학습용 브랜치입니다.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ TailwindCSS
 - [Preflight](https://tailwindcss.com/docs/preflight)
 - [↳ Preflight Stylesheet](https://github.com/tailwindlabs/tailwindcss/blob/main/packages/tailwindcss/preflight.css)
 - [@apply](https://tailwindcss.com/docs/functions-and-directives#apply-directive)
+
+Lucid (Icons)
+
+- [Installation](https://lucide.dev/guide/installation)
+- [Icons](https://lucide.dev/icons/)
 </details>
 
 <br>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.12",
+        "lucide-react": "^0.541.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.8.2",
@@ -2756,6 +2757,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.541.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.541.0.tgz",
+      "integrity": "sha512-s0Vircsu5WaGv2KoJZ5+SoxiAJ3UXV5KqEM3eIFDHaHkcLIFdIWgXtZ412+Gh02UsdS7Was+jvEpBvPCWQISlg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.12",
+    "lucide-react": "^0.541.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.8.2",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,6 @@ import { BrowserRouter, Link, Route, Routes } from "react-router-dom";
 import { ComponentPage, DataPage, EventPage, ListPage, PropsPage, StylePage } from "./basic";
 import BasicLayout from "./layouts/BasicLayout";
 import Header from "./components/header";
-import HomePage from "./pages/HomePage";
 
 export default function App() {
   return (
@@ -12,18 +11,22 @@ export default function App() {
 
       {/* 라우터 매핑: URL → 화면 컴포넌트  */}
       <Routes>
-        {/* Home */}
-        <Route index element={<HomePage />}></Route>
-
-        {/* Basic Layout: React Basic 경로들*/}
         <Route path="/" element={<BasicLayout />}>
-          <Route path="/component" element={<ComponentPage />} />
-          <Route path="/style" element={<StylePage />} />
-          <Route path="/data" element={<DataPage />} />
-          <Route path="/list" element={<ListPage />} />
-          <Route path="/event" element={<EventPage />} />
-          <Route path="/props" element={<PropsPage />} />
+          {/* Basic Layout: React Basic 경로들*/}
+          <Route path="component" element={<ComponentPage />} />
+          <Route path="style" element={<StylePage />} />
+          <Route path="data" element={<DataPage />} />
+          <Route path="list" element={<ListPage />} />
+          <Route path="event" element={<EventPage />} />
+          <Route path="props" element={<PropsPage />} />
         </Route>
+
+        {/* 
+        <Route path="/advanced" element={<AdvancedLayout />}>
+          <Route path="hooks" element={<HooksPage />} />
+          <Route path="context" element={<ContextPage />} />
+        </Route>
+        */}
 
         {/* 404: 정의되지 않은 모든 경로 */}
         <Route path="*" element={<div>페이지를 찾을 수 없습니다</div>} />

--- a/src/basic/ComponentPage.jsx
+++ b/src/basic/ComponentPage.jsx
@@ -1,9 +1,7 @@
 export default function ComponentPage() {
   return (
     <>
-      <header>
-        <h2>컴포넌트 생성 및 중첩하기</h2>
-      </header>
+      <h2>컴포넌트 생성 및 중첩하기</h2>
     </>
   );
 }

--- a/src/components/Breadcrumbs.jsx
+++ b/src/components/Breadcrumbs.jsx
@@ -1,48 +1,76 @@
+// src/components/Breadcrumbs.jsx
+import { ChevronRight } from "lucide-react";
 import { NavLink, useLocation } from "react-router-dom";
 
+// 경로 이름 매핑
 const LABELS = {
-  component: "Basic 컴포넌트 생성 및 중첩하기",
-  style: "Basic JSX 마크업 작성 및 스타일 추가하기",
-  data: "Basic 데이터 표시하기",
-  list: "Basic 조건부 렌더링 · 리스트 렌더링",
-  event: "Basic 이벤트 응답 및 화면 업데이트",
-  props: "Basic 컴포넌트 간에 데이터를 공유하는 방법",
+  "": "React",
+  basic: "React Basic",
+  component: "컴포넌트 생성 및 중첩하기",
+  style: "JSX 마크업 작성 및 스타일 추가하기",
+  data: "데이터 표시하기",
+  list: "조건부 렌더링 · 리스트 렌더링",
+  event: "이벤트 응답 및 화면 업데이트",
+  props: "컴포넌트 간에 데이터를 공유하는 방법",
 };
 
-export default function Breadcrumbs() {
-  const location = useLocation();
-  const pathname = typeof location?.pathname === "string" ? location.pathname : "";
-  const segments = pathname.split("/").filter(Boolean);
+const BASIC_PAGES = new Set(["component", "style", "data", "list", "event", "props"]);
 
-  const crumbs = [
-    { to: "/", label: "Home" },
-    ...segments.map((seg, i) => {
-      const to = "/" + segments.slice(0, i + 1).join("/");
-      return { to, label: LABELS[seg] ?? seg };
-    }),
-  ];
+export default function Breadcrumbs() {
+  // 현재 URL 경로 가져오기
+  const { pathname } = useLocation();
+  // pathname을 "/" 기준으로 나눠 배열로 만들기
+  const segments = (typeof pathname === "string" ? pathname : "").split("/").filter(Boolean);
+  // breadcrumbs 항상 Home으로 시작
+  const crumbs = [{ to: "/", label: LABELS[""] }];
+
+  // 'React Basic' 가상 항목 추가 (카테고리 용도)
+  if (segments[0] && BASIC_PAGES.has(segments[0])) {
+    crumbs.push({ to: null, label: LABELS.basic, virtual: true });
+  }
+  // 누적 경로 acc를 이용해 전체 경로 구성
+  let acc = "";
+  for (const seg of segments) {
+    acc += `/${seg}`;
+    // 'React Basic'은 실제 경로에는 없지만 UX상 중간 단계로 표시하기 위한 가상(Virtual) 항목
+    crumbs.push({ to: acc, label: LABELS[seg] ?? decodeURIComponent(seg) });
+  }
 
   return (
-    <nav aria-label="Breadcrumb" className="text-sm my-2">
+    <nav
+      aria-label="Breadcrumb"
+      className="text-sm py-3 px-10 border-b bg-neutral-900 border-neutral-700"
+    >
       <ol className="flex gap-2">
         {crumbs.map((c, idx) => {
           const isLast = idx === crumbs.length - 1;
           return (
-            <li key={c.to} className="flex items-center gap-2">
-              <NavLink
-                to={c.to}
-                end
-                className={({ isActive }) =>
-                  isLast
-                    ? "text-neutral-400"
-                    : isActive
-                    ? "text-blue-400 font-semibold underline underline-offset-2"
-                    : "text-blue-300 hover:text-blue-400  underline underline-offset-2"
-                }
-              >
-                {c.label}
-              </NavLink>
-              {!isLast && <span className="text-neutral-500">/</span>}
+            <li key={`${c.label}-${idx}`} className="flex items-center gap-2">
+              {/* virtual이면 클릭 불가(span), 나머지는 NavLink*/}
+              {c.virtual ? (
+                <span className="text-neutral-400">{c.label}</span>
+              ) : (
+                <NavLink
+                  to={c.to ?? "/"}
+                  end
+                  className={({ isActive }) =>
+                    isLast
+                      ? // 마지막 항목은 현재 위치 → 링크 없음
+                        "text-neutral-400"
+                      : isActive
+                      ? "text-blue-400 font-semibold underline underline-offset-2"
+                      : "text-blue-300 hover:text-blue-400 underline underline-offset-2"
+                  }
+                >
+                  {c.label}
+                </NavLink>
+              )}
+              {/* 마지막 항목이 아니면 구분자 출력  */}
+              {!isLast && (
+                <span className="text-neutral-500">
+                  <ChevronRight size={16} />
+                </span>
+              )}
             </li>
           );
         })}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -2,10 +2,12 @@ import { Link } from "react-router-dom";
 
 export default function Header() {
   return (
-    <h1 className="text-2xl font-bold p-6">
-      <Link to="/" className="hover:text-blue-300 transition-colors">
-        ⚛️ React
-      </Link>
-    </h1>
+    <header>
+      <h1 className="text-2xl font-bold p-5 border-b-1 border-neutral-700">
+        <Link to="/" className="hover:text-blue-300 transition-colors">
+          ⚛️ React
+        </Link>
+      </h1>
+    </header>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -4,7 +4,3 @@ html,
 body {
   @apply h-screen bg-neutral-950 text-neutral-50;
 }
-
-section {
-  @apply grid px-10 gap-4;
-}

--- a/src/layouts/BasicLayout.jsx
+++ b/src/layouts/BasicLayout.jsx
@@ -1,38 +1,50 @@
-import { Link, Outlet, useLocation } from "react-router-dom";
+import { Link, Outlet, useMatch } from "react-router-dom";
 import Breadcrumbs from "../components/Breadcrumbs";
 
 export default function BasicLayout() {
-  const { pathname } = useLocation();
-  const isRoot = pathname === "/";
+  const isRoot = !!useMatch({ path: "/", end: true });
 
   return (
-    <section>
-      {isRoot && <h2 className="text-xl font-semibold">🥚 React Basic</h2>}
+    <section className={isRoot ? "grid px-10 py-5 gap-4" : "gap-0"}>
+      {isRoot && <h2 className="text-xl font-semibold py-2">🥚 React Basic</h2>}
 
       {isRoot ? (
         <ul className="grid list-disc pl-8 gap-2">
           <li>
-            <Link to="/component">컴포넌트 생성 및 중첩하기</Link>
+            <Link to="component" className="hover:text-blue-300 transition-colors">
+              컴포넌트 생성 및 중첩하기
+            </Link>
           </li>
           <li>
-            <Link to="/style">JSX 마크업 작성 및 스타일 추가하기</Link>
+            <Link to="style" className="hover:text-blue-300 transition-colors">
+              JSX 마크업 작성 및 스타일 추가하기
+            </Link>
           </li>
           <li>
-            <Link to="/data">데이터 표시하기</Link>
+            <Link to="data" className="hover:text-blue-300 transition-colors">
+              데이터 표시하기
+            </Link>
           </li>
           <li>
-            <Link to="/list">조건부 렌더링 · 리스트 렌더링</Link>
+            <Link to="list" className="hover:text-blue-300 transition-colors">
+              조건부 렌더링 · 리스트 렌더링
+            </Link>
           </li>
           <li>
-            <Link to="/event">이벤트 응답 및 화면 업데이트</Link>
+            <Link to="event" className="hover:text-blue-300 transition-colors">
+              이벤트 응답 및 화면 업데이트
+            </Link>
           </li>
           <li>
-            <Link to="/props">컴포넌트 간에 데이터를 공유하는 방법</Link>
+            <Link to="props" className="hover:text-blue-300 transition-colors">
+              컴포넌트 간에 데이터를 공유하는 방법
+            </Link>
           </li>
         </ul>
       ) : (
         <Breadcrumbs />
       )}
+
       <Outlet />
     </section>
   );

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,5 +1,0 @@
-import BasicLayout from "../layouts/BasicLayout";
-
-export default function HomePage() {
-  return <BasicLayout />;
-}


### PR DESCRIPTION
## ⚛️ React Docs 기반 학습 PR

- Branch: study
- Subject: 브라우저 경로(pathname)를 기반으로 동적으로 Breadcrumbs UI 구현, 전체 레이아웃 구조 작업

<br>

## 🧩 Implementation

- `useLocation()`을 사용하여 현재 브라우저의 URL 경로(`pathname`)를 감지
- 경로를 `/` 기준으로 분할하여 `LABELS` 객체와 매핑 후, 텍스트 표시
- 특정 경로(component, style 등)에 대해 'React Basic'이라는 가상 카테고리를 추가 (virtual breadcrumb)
- `lucide-react` 아이콘을 Breadcrumbs 구분자로 사용

<br>

## 📌 What I Learned

- React Router의 `useLocation()` 훅을 통해 URL 정보를 가져오는 방식
- `pathname`을 파싱하여 동적으로 UI를 구성하는 로직 작성 방법
- "virtual breadcrumb"처럼 실제 경로에 존재하지 않지만 UX 흐름상 필요한 항목을 가상으로 삽입하는 개념

<br>

## 📚 Reference

React

- [React Docs EN](https://react.dev/)
- [React Docs KO](https://react.dev/)

React Router

- [NavLink](https://reactrouter.com/api/components/NavLink#navlink)
- [useLocation](https://reactrouter.com/api/hooks/useLocation)

TailwindCSS

- [Installation](https://tailwindcss.com/docs/installation/using-vite)
- [Preflight](https://tailwindcss.com/docs/preflight)
- [↳ Preflight Stylesheet](https://github.com/tailwindlabs/tailwindcss/blob/main/packages/tailwindcss/preflight.css)
- [@apply](https://tailwindcss.com/docs/functions-and-directives#apply-directive)

Lucid (Icons)

- [Installation](https://lucide.dev/guide/installation)
- [Icons](https://lucide.dev/icons/)

<br>

---

💡 이 브랜치는 React 공식 문서 기반 학습용 브랜치입니다.
